### PR TITLE
Remove duplicate Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.MD
+++ b/CODE_OF_CONDUCT.MD
@@ -1,6 +1,0 @@
-## Community Participation Guidelines
-
-This repository is governed by Mozilla's code of conduct and etiquette guidelines. 
-For more details please see the 
-[Mozilla Community Participation Guidelines](https://www.mozilla.org/about/governance/policies/participation/) 
-


### PR DESCRIPTION
Remove duplicate Code of Conduct, as the repository contains both a `CODE_OF_CONDUCT.md` and a `CODE_OF_CONDUCT.MD` file. Leaving both files in the repository will result in error being shown when cloning the repository on case insensitive file systems.